### PR TITLE
fix: Remove faulty "typeof"

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -249,7 +249,7 @@ function readPayload(script, callback) {
       let csvOpts = {
         skip_empty_lines: typeof payloadSpec.skipEmptyLines === 'undefined' ? true : payloadSpec.skipEmptyLines,
         cast: typeof payloadSpec.cast === 'undefined' ? true : payloadSpec.cast,
-        from_line: typeof payloadSpec.skipHeader === true ? 2 : 1,
+        from_line: payloadSpec.skipHeader === true ? 2 : 1,
         delimiter: payloadSpec.delimiter || ','
       };
       // Defaults may still be overridden:


### PR DESCRIPTION
```js
from_line: typeof payloadSpec.skipHeader === true ? 2 : 1
```
The above always evaluates to `1`, as `typeof payloadSpec.skipHeader` is `boolean`, which doesn't `=== true`.